### PR TITLE
Gh 7 & GH-8 -- fixed both defects and added AuthScreen

### DIFF
--- a/App.js
+++ b/App.js
@@ -17,6 +17,7 @@ import FilterScreen from './src/screens/FilterScreen';
 import FavoritesScreen from './src/screens/FavoritesScreen';
 import AddSiteScreen from './src/screens/AddSiteScreen';
 import MoreScreen from './src/screens/MoreScreen';
+import AuthScreen from "./src/screens/AuthScreen";
 
 const store = createStore(
     reducers,
@@ -38,6 +39,9 @@ class App extends Component {
         const MainNavigator = StackNavigator({
             [navKeys.LOGIN]: {
                 screen: LoginScreen
+            },
+            [navKeys.AUTH]: {
+                screen: AuthScreen
             },
             [navKeys.MAIN]: {
                 screen: TabNavigator({

--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
     "privacy": "unlisted",
     "sdkVersion": "24.0.0",
     "platforms": ["ios", "android"],
-    "version": "1.0.0",
+    "version": "0.0.1",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "splash": {

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "campo-libre",
-    "description": "This project is really great.",
+    "name": "Campo Libre",
+    "description": "Get out there...",
     "slug": "campo-libre",
     "privacy": "unlisted",
     "sdkVersion": "24.0.0",

--- a/src/actions/AuthActions.js
+++ b/src/actions/AuthActions.js
@@ -13,7 +13,7 @@ import {
 } from './types';
 
 import {FACEBOOK_AUTH} from '../../env';
-import {tokens} from '../constants';
+import {tokens, navKeys} from '../constants';
 
 const attemptFacebookLogin = async (dispatch) => {
     const {appID} = FACEBOOK_AUTH;
@@ -46,23 +46,24 @@ export const logUserIntoFacebook = () => {
         let token = await AsyncStorage.getItem(tokens.USER_TOKEN);
 
         if (token) {
-            checkAndSetToken(token);
+            checkAndSetToken({token});
         } else {
             attemptFacebookLogin(dispatch);
         }
     }
 };
 
-export const checkAndSetToken = (passedToken) => {
+export const checkAndSetToken = ({token, navigate}) => {
 
     return async (dispatch) => {
-        let token = passedToken;
 
         if (!token) {
             token = await AsyncStorage.getItem(tokens.USER_TOKEN);
         }
 
         if (token) {
+            navigate(navKeys.SEARCH);
+
             if (token === tokens.GUEST) {
                 dispatch({
                     type: GUEST_TOKEN_SET,
@@ -82,7 +83,7 @@ export const checkAndSetToken = (passedToken) => {
     }
 };
 
-export const setGuestToken = () => {
+export const setGuestToken = ({navigate}) => {
 
     return async (dispatch) => {
         await AsyncStorage.setItem(tokens.USER_TOKEN, tokens.GUEST);
@@ -91,15 +92,19 @@ export const setGuestToken = () => {
             type: GUEST_TOKEN_SET,
             payload: tokens.GUEST
         });
+
+        navigate(navKeys.SEARCH);
     };
 };
 
-export const logUserOutOfFacebook = () => {
+export const logUserOutOfFacebook = ({navigate}) => {
     return async (dispatch) => {
         await AsyncStorage.removeItem(tokens.USER_TOKEN);
 
         dispatch({
             type: FACEBOOK_LOGOUT_COMPLETE
         });
+
+        navigate(navKeys.LOGIN);
     };
 };

--- a/src/actions/MapActions.js
+++ b/src/actions/MapActions.js
@@ -17,13 +17,11 @@ export const initializeMap = () => {
 };
 
 export const updateViewStyle = (newViewStyle) => {
-    const thingToReturn = {
+    return {
         type: VIEW_STYLE_UPDATE,
         payload: newViewStyle
 
     };
-
-    return thingToReturn;
 };
 
 export const mapLoaded = () => {

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -2,7 +2,7 @@ export const APP_READY = 'app_ready';
 
 export const GUEST_TOKEN_SET = 'guest_token_set';
 export const FACEBOOK_LOGIN_SUCCESS = 'fb_login_success';
-export const FACEBOOK_LOGIN_FAILURE = 'fb_login_success';
+export const FACEBOOK_LOGIN_FAILURE = 'fb_login_failure';
 export const FACEBOOK_LOGOUT_COMPLETE = 'fb_logout_complete';
 
 export const INITIALIZE_MAP = 'initialize_map';

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,11 +11,12 @@ export const tokens = {
 };
 
 export const navKeys = {
-  LOGIN: 'login',
-  MAIN: 'main',
-  SEARCH: 'search',
-  FAVORITES: 'favorites',
-  ADD_SITE: 'addSite',
-  MORE: 'more',
-  FILTER: 'filter'
+    LOGIN: 'login',
+    AUTH: 'auth',
+    MAIN: 'main',
+    SEARCH: 'search',
+    FAVORITES: 'favorites',
+    ADD_SITE: 'addSite',
+    MORE: 'more',
+    FILTER: 'filter'
 };

--- a/src/reducers/AuthReducer.js
+++ b/src/reducers/AuthReducer.js
@@ -3,7 +3,8 @@ import {
     FACEBOOK_LOGIN_SUCCESS,
     FACEBOOK_LOGIN_FAILURE,
     FACEBOOK_LOGOUT_COMPLETE,
-    GUEST_TOKEN_SET
+    GUEST_TOKEN_SET,
+    MAP_READY
 } from '../actions/types';
 
 const INITIAL_STATE = {
@@ -17,13 +18,16 @@ export default (state = INITIAL_STATE, action) => {
     switch (type) {
 
         case APP_READY:
-            return({...state, appReady: true});
+            return ({...state, appReady: true});
+
+        case MAP_READY:
+            return ({...state, appReady: true});
 
         case GUEST_TOKEN_SET:
-            return({...state, token: payload.token, appReady: payload.appReady});
+            return ({...state, token: payload.token, appReady: payload.appReady});
 
         case FACEBOOK_LOGIN_SUCCESS:
-            return({...state, token: payload.token, appReady: payload.appReady});
+            return ({...state, token: payload.token, appReady: payload.appReady});
 
         case FACEBOOK_LOGIN_FAILURE:
             return ({...state, token: null});

--- a/src/screens/AuthScreen.js
+++ b/src/screens/AuthScreen.js
@@ -1,0 +1,33 @@
+// 3rd part libraries - core
+import {AppLoading} from 'expo';
+import React, {Component} from 'react';
+import {connect} from 'react-redux';
+
+// actions
+
+// language and styles
+
+// our components - core
+// our components - additional
+
+class AuthScreen extends Component {
+    static navigationOptions = (props) => {
+
+        return {
+            header: null
+        }
+    };
+
+    render() {
+        return <AppLoading/>
+    }
+}
+
+const styles = {};
+
+const mapStateToProps = (state, ownProps) => {
+
+    return {};
+};
+
+export default connect(mapStateToProps, {})(AuthScreen);

--- a/src/screens/LoginScreen.js
+++ b/src/screens/LoginScreen.js
@@ -13,7 +13,6 @@ import {checkAndSetToken, setGuestToken, logUserIntoFacebook} from '../actions/i
 // language and styles
 import {textDark, lightwhiteblue, facebookBlue, grayblue, navyBlue} from '../styles/index';
 import {login} from '../locale.en';
-import {navKeys} from '../constants';
 
 const {campo_libre, tagline, login_as_guest, login_with_facebook} = login;
 
@@ -24,19 +23,15 @@ const {campo_libre, tagline, login_as_guest, login_with_facebook} = login;
 class LoginScreen extends Component {
 
     componentWillMount() {
-        this.props.checkAndSetToken();
-    }
+        const {navigation: {navigate}} = this.props;
 
-    componentWillReceiveProps(nextProps) {
-        const {token, navigation: {navigate}} = nextProps;
-
-        if (token) {
-            navigate(navKeys.SEARCH);
-        }
+        this.props.checkAndSetToken({navigate});
     }
 
     onPressContinueAsGuest = () => {
-        this.props.setGuestToken();
+        const {navigation: {navigate}} = this.props;
+
+        this.props.setGuestToken({navigate});
     };
 
     onPressFacebookLogin = () => {

--- a/src/screens/LoginScreen.js
+++ b/src/screens/LoginScreen.js
@@ -35,11 +35,12 @@ class LoginScreen extends Component {
     };
 
     onPressFacebookLogin = () => {
-        this.props.logUserIntoFacebook();
+        const {navigation: {navigate}} = this.props;
+
+        this.props.logUserIntoFacebook({navigate});
     };
 
     static navigationOptions = (props) => {
-        const {navigation: {navigate}} = props;
 
         return {
             header: null
@@ -47,12 +48,6 @@ class LoginScreen extends Component {
     };
 
     renderPage() {
-        const {appReady} = this.props;
-
-        if (!appReady) {
-            return <AppLoading />
-        }
-
         const {containerStyle, topContainer, heroContainer, buttonContainer, buttonStyle, facebookStyle} = styles;
 
         return (
@@ -95,6 +90,12 @@ class LoginScreen extends Component {
 
     render() {
         const {fillScreen} = styles;
+        const {appReady} = this.props;
+
+        if (!appReady) {
+            return <AppLoading />
+
+        }
 
         return (
             <View style={fillScreen}>

--- a/src/screens/MoreScreen.js
+++ b/src/screens/MoreScreen.js
@@ -11,25 +11,13 @@ import {navKeys} from '../constants';
 
 class MoreScreen extends Component {
     componentDidMount() {
-        const {token, navigation: {navigate, state: {key}}} = this.props;
-
-        if (!token && key !== navKeys.LOGIN) {
-            navigate(navKeys.LOGIN);
-        }
-
         this.props.navigation.setParams({onLogout: this.onLogout});
     }
 
-    componentWillReceiveProps(nextProps) {
-        const {token, navigation: {navigate, state: {key}}} = nextProps;
-
-        if (!token) {
-            navigate(navKeys.LOGIN);
-        }
-    }
-
     onLogout = () => {
-        this.props.logUserOutOfFacebook();
+        const {navigation: {navigate}} = this.props;
+
+        this.props.logUserOutOfFacebook({navigate});
     };
 
     static renderRightNavButton = ({onLogout}) => {

--- a/src/screens/SearchScreen.js
+++ b/src/screens/SearchScreen.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import {View, Text, ActivityIndicator, StyleSheet, Platform, Keyboard} from 'react-native';
 import {Button, Card} from 'react-native-elements';
-import {MapView} from 'expo';
+import {MapView, AppLoading} from 'expo';
 import {Icon} from 'react-native-elements';
 import {connect} from 'react-redux';
 
@@ -14,12 +14,6 @@ import {map, navKeys} from '../constants';
 
 class SearchScreen extends Component {
     componentWillMount() {
-        const {token, navigation: {navigate, state: {key}}} = this.props;
-
-        if (!token && key !== navKeys.LOGIN) {
-            navigate(navKeys.LOGIN);
-        }
-
         this.props.initializeMap();
     }
 
@@ -163,7 +157,7 @@ const styles = StyleSheet.create({
 
 function mapStateToProps(state) {
     const {region, mapLoaded, viewStyle} = state.map;
-    const {token} = state.auth;
+    const {token, appReady} = state.auth;
 
 
     return {region, mapLoaded, viewStyle, token};

--- a/src/screens/SearchScreen.js
+++ b/src/screens/SearchScreen.js
@@ -137,6 +137,12 @@ class SearchScreen extends Component {
 
     render() {
         const {fillScreen} = styles;
+        const {appReady} = this.props;
+
+        if (!appReady) {
+            return <AppLoading />
+
+        }
 
         return (
             <View style={fillScreen}>
@@ -160,7 +166,7 @@ function mapStateToProps(state) {
     const {token, appReady} = state.auth;
 
 
-    return {region, mapLoaded, viewStyle, token};
+    return {region, mapLoaded, viewStyle, token, appReady};
 }
 
 export default connect(mapStateToProps, {initializeMap, updateViewStyle, mapLoaded, updateRegion})(SearchScreen);


### PR DESCRIPTION
 * Both GH-7 and GH-8 were resolved by passing `navigate` as props to the Actions and having them handle navigation
 * After a successful Facebook login, the user was seeing the `LoginScreen` flicker again before they were re-routed. I created an `AuthScreen` which only renders `<AppLoading />` to be the background during this process. 