### PR TITLE
Gh 44 -- Create filter fields and enable filter functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3069,6 +3069,13 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3076,13 +3083,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -3952,6 +3952,13 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3959,13 +3966,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
           }
         },
         "stringstream": {
@@ -5989,6 +5989,14 @@
       "resolved": "https://registry.npmjs.org/react-native-branch/-/react-native-branch-2.0.0-beta.3.tgz",
       "integrity": "sha1-IWevhrvJ+WS9Rb1fN2hOW1SWXjI="
     },
+    "react-native-collapsible": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/react-native-collapsible/-/react-native-collapsible-0.10.0.tgz",
+      "integrity": "sha512-u9etmvJUDUCMBk2dL3bqIY4J1G0ypFddX+eAPJtIqVPMIFFw3x1yNkSS6ig4XWTXQMx4iMPOrSKxfSeBisXmIg==",
+      "requires": {
+        "prop-types": "15.6.0"
+      }
+    },
     "react-native-dismiss-keyboard": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/react-native-dismiss-keyboard/-/react-native-dismiss-keyboard-1.0.0.tgz",
@@ -6700,6 +6708,11 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -6728,11 +6741,6 @@
           }
         }
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "ionicons": "^3.0.0",
     "react": "16.0.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-24.0.0.tar.gz",
+    "react-native-collapsible": "^0.10.0",
     "react-native-elements": "^0.19.0",
     "react-native-linear-gradient": "^2.4.0",
     "react-native-vector-icons": "^4.5.0",

--- a/src/actions/AddSiteActions.js
+++ b/src/actions/AddSiteActions.js
@@ -12,6 +12,7 @@ import {
     SITE_NEAREST_TOWN_TEXT_CHANGED,
     SITE_ACCESSIBILITY_OPTION_CHANGED,
     SITE_FACILITIES_OPTION_CHANGED,
+    SITE_PRICE_OPTION_CHANGED,
     ADD_SITE_FIELDS_RESET,
     ADD_SITE_SUCCESS,
     ADD_SITE_FAILURE,
@@ -86,6 +87,13 @@ export const updateFacilitiesOption = ({facilitiesOption}) => {
     }
 };
 
+export const updatePriceOption = ({priceOption}) => {
+    return {
+        type: SITE_PRICE_OPTION_CHANGED,
+        payload: {priceOption}
+    }
+};
+
 export const resetAddScreenFields = () => {
     return {
         type: ADD_SITE_FIELDS_RESET
@@ -99,7 +107,7 @@ export const checkIfSiteIsReadyForUpload = () => {
 };
 
 
-export const attemptToUploadSite = ({title, description, directions, nearestTown, accessibility, facilities, coordinate}) => {
+export const attemptToUploadSite = ({title, description, directions, nearestTown, accessibility, facilities, price, coordinate}) => {
     const {longitude, latitude} = coordinate;
     const uniqueTitle = `${title}${longitude}${latitude}`;
 
@@ -112,6 +120,7 @@ export const attemptToUploadSite = ({title, description, directions, nearestTown
                 nearestTown,
                 accessibility,
                 facilities,
+                price,
                 coordinate
             })
             .then(() => {

--- a/src/actions/SearchAndFilterActions.js
+++ b/src/actions/SearchAndFilterActions.js
@@ -1,0 +1,11 @@
+import {
+    FILTER_CRITERIA_UPDATED
+} from './types';
+
+
+export const checkboxWasClicked = ({filterKey}) => {
+    return{
+        type: FILTER_CRITERIA_UPDATED,
+        payload: {filterKey}
+    }
+};

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -2,3 +2,4 @@ export * from './AuthActions';
 export * from './MapActions';
 export * from './AddSiteActions';
 export * from './PermissionsActions';
+export * from './SearchAndFilterActions';

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -28,6 +28,8 @@ export const ADD_SITE_SUCCESS = 'add_site_success';
 export const ADD_SITE_FAILURE = 'add_site_failure';
 export const CHECK_IF_SITE_IS_READY = 'check_if_site_is_ready';
 
+export const FILTER_CRITERIA_UPDATED = 'filter_criteria_updated';
+
 export const LOCATION_SERVICES_PERMISSION_UPDATED = 'location_services_permission_updated';
 export const CAMERA_PERMISSION_UPDATED = 'camera_permission_updated';
 export const CAMERA_ROLL_PERMISSION_UPDATED = 'camera_roll_permission_updated';

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -21,6 +21,7 @@ export const SITE_DIRECTIONS_TEXT_CHANGED = 'site_directions_text_changed';
 export const SITE_NEAREST_TOWN_TEXT_CHANGED = 'site_nearest_town_text_changed';
 export const SITE_ACCESSIBILITY_OPTION_CHANGED = 'site_accessibility_option_changed';
 export const SITE_FACILITIES_OPTION_CHANGED = 'site_facilities_option_changed';
+export const SITE_PRICE_OPTION_CHANGED = 'site_price_option_changed';
 export const ADD_SITE_FIELDS_RESET = 'add_site_fields_reset';
 export const CURRENT_LOCATION_UPDATED = 'current_location_updated';
 export const ADD_SITE_SUCCESS = 'add_site_success';

--- a/src/locale.en.js
+++ b/src/locale.en.js
@@ -39,9 +39,9 @@ export const campsite = {
             permit: 'Permit'
         },
         facilities_options: {
-            full_service: 'Full Service ',
-            some: 'Some',
-            none: 'None'
+            full_service: 'Full Service',
+            some_facilities: 'Some',
+            no_facilities: 'None'
         },
         accessibility_options: {
             paved_road: "Paved Road",
@@ -62,7 +62,6 @@ export const reducerAlerts = {
 export const more_screen = {
     right_nav: 'Log Out'
 };
-
 
 export const submit_form = {
     submit: 'submit',

--- a/src/locale.en.js
+++ b/src/locale.en.js
@@ -32,13 +32,16 @@ export const campsite = {
         here_now: 'I am here now',
         accessibility: 'Accessibility',
         facilities: 'Facilities',
+        price: 'Price',
+        price_options: {
+            free: 'Free',
+            paid: 'Paid',
+            permit: 'Permit'
+        },
         facilities_options: {
             full_service: 'Full Service ',
             some: 'Some',
-            none: 'None',
-            permit: 'Permit',
-            paid: 'Paid',
-            free: 'Free'
+            none: 'None'
         },
         accessibility_options: {
             paved_road: "Paved Road",

--- a/src/reducers/AddSiteReducer.js
+++ b/src/reducers/AddSiteReducer.js
@@ -11,6 +11,7 @@ import {
     SITE_NEAREST_TOWN_TEXT_CHANGED,
     SITE_ACCESSIBILITY_OPTION_CHANGED,
     SITE_FACILITIES_OPTION_CHANGED,
+    SITE_PRICE_OPTION_CHANGED,
     ADD_SITE_FIELDS_RESET,
     CURRENT_LOCATION_UPDATED,
     CHECK_IF_SITE_IS_READY,
@@ -20,7 +21,7 @@ import {
 
 import {campsite, reducerAlerts} from '../locale.en';
 
-const {campsite_form: {accessibility_options, facilities_options}} = campsite;
+const {campsite_form: {accessibility_options, facilities_options, price_options}} = campsite;
 
 const INITIAL_STATE = {
     addSiteModalVisible: false,
@@ -34,6 +35,7 @@ const INITIAL_STATE = {
     siteNearestTownText: '',
     accessibilityOption: accessibility_options.paved_road,
     facilitiesOption: facilities_options.full_service,
+    priceOption: price_options.free,
     siteReadyForUpload: false,
     sitesShouldUpdate: false
 };
@@ -42,8 +44,8 @@ const removeNonNumbers = (text) => {
     return text.replace(/[^0-9.-]/g, '');
 };
 
-const siteIsReadyForUpload = ({latitudeText, longitudeText, siteTitleText, siteDescriptionText, siteDirectionsText, siteNearestTownText, accessibilityOption, facilitiesOption}) => {
-    return latitudeText && longitudeText && siteTitleText && siteDescriptionText && siteDirectionsText && siteNearestTownText && accessibilityOption && facilitiesOption;
+const siteIsReadyForUpload = ({latitudeText, longitudeText, siteTitleText, siteDescriptionText, siteDirectionsText, siteNearestTownText, accessibilityOption, facilitiesOption, priceOption}) => {
+    return latitudeText && longitudeText && siteTitleText && siteDescriptionText && siteDirectionsText && siteNearestTownText && accessibilityOption && facilitiesOption && priceOption;
 };
 
 export default (state = INITIAL_STATE, action) => {
@@ -94,6 +96,10 @@ export default (state = INITIAL_STATE, action) => {
         case SITE_FACILITIES_OPTION_CHANGED:
             const {facilitiesOption} = payload;
             return {...state, facilitiesOption};
+
+        case SITE_PRICE_OPTION_CHANGED:
+            const {priceOption} = payload;
+            return {...state, priceOption};
 
         case ADD_SITE_FIELDS_RESET:
             return {...INITIAL_STATE, addSiteModalVisible: true};

--- a/src/reducers/MapReducer.js
+++ b/src/reducers/MapReducer.js
@@ -1,12 +1,19 @@
+import _ from 'lodash';
+
 import {
     INITIALIZE_MAP,
     VIEW_STYLE_UPDATE,
     MAP_READY,
-    MAP_REGION_CHANGE, FACEBOOK_LOGOUT_COMPLETE
+    MAP_REGION_CHANGE,
+    FACEBOOK_LOGOUT_COMPLETE,
+    FILTER_CRITERIA_UPDATED
 
 } from '../actions/types';
 
 import {map} from "../constants";
+import {campsite} from '../locale.en';
+
+const {campsite_form: {accessibility_options, facilities_options, price_options}} = campsite;
 
 const sampleSiteMarkers = [
     {
@@ -47,10 +54,79 @@ const INITIAL_STATE = {
     },
     mapLoaded: false,
     viewStyle: map.SearchOptions.MAP,
-    sites: []
+    sites: [],
+    displaySites: [],
+    filterCriteriaKeys: {accessibility: [], facilities: [], price: []}
 };
 
+const updateFilterKeys = ({filterCriteriaKeys}, filterKey) => {
+    let filterCriteriaSubKey = null;
 
+    if (_.includes(_.keys(accessibility_options), filterKey)) {
+        filterCriteriaSubKey = 'accessibility';
+    } else if (_.includes(_.keys(facilities_options), filterKey)) {
+        filterCriteriaSubKey = 'facilities';
+    } else if (_.includes(_.keys(price_options), filterKey)) {
+        filterCriteriaSubKey = 'price';
+    }
+
+    const keyIsAlreadyInList = _.includes(filterCriteriaKeys[filterCriteriaSubKey], filterKey);
+    let updatedFilterKeyList = _.cloneDeep(filterCriteriaKeys);
+
+    if (keyIsAlreadyInList) {
+        updatedFilterKeyList[filterCriteriaSubKey] = _.reject(filterCriteriaKeys[filterCriteriaSubKey], existingFilterKey => existingFilterKey === filterKey);
+    } else {
+        updatedFilterKeyList[filterCriteriaSubKey] = _.concat(filterCriteriaKeys[filterCriteriaSubKey], filterKey);
+    }
+
+    return updatedFilterKeyList;
+};
+
+const filterSites = ({sites}, updatedFilterKeys) => {
+    if (updatedFilterKeys.length === 0) {
+        return sites;
+    }
+
+    const allPossibleFilterOptions = _.reduce([accessibility_options, facilities_options, price_options], (acc, optionObject) => {
+        _.forEach(optionObject, (value, key) => {
+            acc[key] = value;
+        });
+
+        return acc;
+    }, {});
+
+    const filteredSites = _.filter(sites, site => {
+        const {accessibility, price, facilities} = site;
+        let accessibilityMatch = false;
+        let facilitiesMatch = false;
+        let priceMatch = false;
+
+        if (updatedFilterKeys.accessibility.length === 0) {
+            accessibilityMatch = true;
+        } else {
+            const accessibilityFullTextArray = _.map(updatedFilterKeys.accessibility, filterKey => accessibility_options[filterKey]);
+            accessibilityMatch = _.includes(accessibilityFullTextArray, accessibility);
+        }
+
+        if (updatedFilterKeys.facilities.length === 0) {
+            facilitiesMatch = true;
+        } else {
+            const facilitiesFullTextArray = _.map(updatedFilterKeys.facilities, filterKey => facilities_options[filterKey]);
+            facilitiesMatch = _.includes(facilitiesFullTextArray, facilities);
+        }
+
+        if (updatedFilterKeys.price.length === 0) {
+            priceMatch = true;
+        } else {
+            const pricesFullTextArray = _.map(updatedFilterKeys.price, filterKey => price_options[filterKey]);
+            priceMatch = _.includes(pricesFullTextArray, price);
+        }
+
+        return accessibilityMatch && facilitiesMatch && priceMatch;
+    });
+
+    return filteredSites;
+};
 
 export default (state = INITIAL_STATE, action) => {
     const {type, payload} = action;
@@ -61,7 +137,14 @@ export default (state = INITIAL_STATE, action) => {
             const {region, sites} = payload;
             const existingMapLoadedState = state.mapLoaded;
 
-            return payload ? {...INITIAL_STATE, lastKnownRegion: region, sites, mapLoaded: existingMapLoadedState} : INITIAL_STATE;
+            return payload ? {
+                ...INITIAL_STATE,
+                lastKnownRegion: region,
+                sites: sites,
+                filterCriteriaKeys: state.filterCriteriaKeys,
+                displaySites: filterSites({sites}, state.filterCriteriaKeys),
+                mapLoaded: existingMapLoadedState
+            } : INITIAL_STATE;
 
         case VIEW_STYLE_UPDATE:
             return {...state, viewStyle: payload};
@@ -74,6 +157,14 @@ export default (state = INITIAL_STATE, action) => {
 
         case FACEBOOK_LOGOUT_COMPLETE:
             return INITIAL_STATE;
+
+        case FILTER_CRITERIA_UPDATED:
+            const {filterKey} = payload;
+            const updatedFilterKeys = updateFilterKeys(state, filterKey);
+            const newlyFilteredSites = filterSites(state, updatedFilterKeys);
+
+            return {...state, filterCriteriaKeys: updatedFilterKeys, displaySites: newlyFilteredSites};
+
 
         default:
             return state;

--- a/src/reducers/MapReducer.js
+++ b/src/reducers/MapReducer.js
@@ -87,14 +87,6 @@ const filterSites = ({sites}, updatedFilterKeys) => {
         return sites;
     }
 
-    const allPossibleFilterOptions = _.reduce([accessibility_options, facilities_options, price_options], (acc, optionObject) => {
-        _.forEach(optionObject, (value, key) => {
-            acc[key] = value;
-        });
-
-        return acc;
-    }, {});
-
     const filteredSites = _.filter(sites, site => {
         const {accessibility, price, facilities} = site;
         let accessibilityMatch = false;

--- a/src/reducers/MapReducer.js
+++ b/src/reducers/MapReducer.js
@@ -83,7 +83,7 @@ const updateFilterKeys = ({filterCriteriaKeys}, filterKey) => {
 };
 
 const filterSites = ({sites}, updatedFilterKeys) => {
-    if (updatedFilterKeys.length === 0) {
+    if (updatedFilterKeys.accessibility.length === 0 && updatedFilterKeys.facilities.length === 0 && updatedFilterKeys.price.length === 0) {
         return sites;
     }
 

--- a/src/screens/AddSiteScreen.js
+++ b/src/screens/AddSiteScreen.js
@@ -13,6 +13,7 @@ import {
     updateSiteNearestTownText,
     updateAccessibilityOption,
     updateFacilitiesOption,
+    updatePriceOption,
     resetAddScreenFields,
     promptForLocationServicesPermission,
     getCurrentUserLocation,
@@ -34,9 +35,10 @@ const {
         directions, directions_placeholder,
         nearest_town, nearest_town_placeholder,
         here_now, add_site,
-        accessibility, facilities,
+        accessibility, facilities, price,
         accessibility_options,
         facilities_options,
+        price_options
     }
 } = campsite;
 
@@ -83,6 +85,12 @@ class AddSiteScreen extends Component {
         })
     }
 
+    priceOptions() {
+        return Object.keys(price_options).map((key) => {
+            return <Picker.Item key={key} label={price_options[key]} value={price_options[key]}/>;
+        })
+    }
+
     onClickOpenModal = () => {
         this.props.openSiteUploadModal();
     };
@@ -123,6 +131,10 @@ class AddSiteScreen extends Component {
         this.props.updateFacilitiesOption({facilitiesOption: newFacilitiesOption})
     };
 
+    onUpdatePriceOption = (newPriceOption) => {
+        this.props.updatePriceOption({priceOption: newPriceOption})
+    };
+
     onClickReset = () => {
         this.props.resetAddScreenFields();
     };
@@ -145,6 +157,7 @@ class AddSiteScreen extends Component {
             nearestTown: this.props.siteNearestTownText,
             accessibility: this.props.accessibilityOption,
             facilities: this.props.facilitiesOption,
+            price: this.props.priceOption,
             coordinate: {
                 longitude: this.props.readyLongitude,
                 latitude: this.props.readyLatitude
@@ -181,7 +194,7 @@ class AddSiteScreen extends Component {
 
     render() {
         const {buttonStyle, headerTitle, largeTextInput, modalStyle, exitOrResetStyle} = styles;
-        const {addSiteModalVisible, latitudeText, longitudeText, siteTitleText, siteDescriptionText, siteDirectionsText, siteNearestTownText, accessibilityOption, facilitiesOption} = this.props;
+        const {addSiteModalVisible, latitudeText, longitudeText, siteTitleText, siteDescriptionText, siteDirectionsText, siteNearestTownText, accessibilityOption, facilitiesOption, priceOption} = this.props;
 
         return (
             <View>
@@ -285,7 +298,7 @@ class AddSiteScreen extends Component {
                             editable={true}
                         />
 
-                        <FormLabel>{directions_placeholder}</FormLabel>
+                        <FormLabel>{directions}</FormLabel>
                         <FormInput
                             placeholder={directions_placeholder}
                             value={siteDirectionsText}
@@ -304,6 +317,14 @@ class AddSiteScreen extends Component {
                             onChangeText={this.onUpdateSiteNearestTownText}
                             editable={true}
                         />
+
+                        <FormLabel>{price}</FormLabel>
+                        <Picker
+                            selectedValue={priceOption}
+                            onValueChange={this.onUpdatePriceOption}
+                        >
+                            {this.priceOptions()}
+                        </Picker>
 
                         <FormLabel>{accessibility}</FormLabel>
                         <Picker
@@ -369,7 +390,7 @@ const styles = {
 };
 
 function mapStateToProps(state) {
-    const {addSiteModalVisible, latitudeText, longitudeText, siteTitleText, siteDescriptionText, siteDirectionsText, siteNearestTownText, accessibilityOption, facilitiesOption, siteReadyForUpload, readyLatitude, readyLongitude} = state.addSite;
+    const {addSiteModalVisible, latitudeText, longitudeText, siteTitleText, siteDescriptionText, siteDirectionsText, siteNearestTownText, accessibilityOption, facilitiesOption, priceOption, siteReadyForUpload, readyLatitude, readyLongitude} = state.addSite;
     const {locationServicesPermission, cameraPermission, cameraRollPermission} = state.permissions;
 
 
@@ -383,6 +404,7 @@ function mapStateToProps(state) {
         siteNearestTownText,
         accessibilityOption,
         facilitiesOption,
+        priceOption,
         locationServicesPermission,
         cameraPermission,
         cameraRollPermission,
@@ -401,6 +423,7 @@ export default connect(mapStateToProps, {
     updateSiteNearestTownText,
     updateAccessibilityOption,
     updateFacilitiesOption,
+    updatePriceOption,
     resetAddScreenFields,
     promptForLocationServicesPermission,
     getCurrentUserLocation,

--- a/src/screens/FilterScreen.js
+++ b/src/screens/FilterScreen.js
@@ -1,10 +1,23 @@
 import React, {Component} from 'react';
-import {Text} from 'react-native';
+import {Text, ScrollView, View, StyleSheet} from 'react-native';
+import {connect} from "react-redux";
 
+import Accordion from 'react-native-collapsible/Accordion';
 
-
-import {CardSection, Card} from '../components/common/index';
 import MapScreen from "../components/SearchMap";
+import {initializeMap, mapHasLoaded, updateRegion, updateViewStyle} from "../actions";
+
+
+const SECTIONS = [
+    {
+        title: 'Accessibility',
+        content: 'Lorem ipsum...'
+    },
+    {
+        title: 'Second',
+        content: 'Lorem ipsum...'
+    }
+];
 
 class FilterScreen extends Component {
 
@@ -17,18 +30,53 @@ class FilterScreen extends Component {
 
     };
 
+    renderHeader(section) {
+        const {headerStyle, headerTextStyle} = styles;
+
+        return (
+            <View style={headerStyle}>
+                <Text style={headerTextStyle}>{section.title}</Text>
+            </View>
+        );
+    }
+
+    renderContent(section) {
+        const {contentStyle, contentTextStyle} = styles;
+
+        return (
+            <View style={contentStyle}>
+                <Text>{section.content}</Text>
+            </View>
+        );
+    }
 
     render(){
         return(
-            <Card>
-                <CardSection>
-                    <Text>
-                        Filter your sites
-                    </Text>
-                </CardSection>
-            </Card>
+            <ScrollView>
+                <Accordion
+                    sections={SECTIONS}
+                    renderHeader={this.renderHeader}
+                    renderContent={this.renderContent}
+                />
+            </ScrollView>
         );
     }
 }
 
-export default FilterScreen;
+const styles = StyleSheet.create({
+    headerStyle: {},
+    headerTextStyle: {},
+    contentStyle:{},
+    contentTextStyle:{}
+});
+
+function mapStateToProps(state) {
+    const {lastKnownRegion, mapLoaded, viewStyle, sites} = state.map;
+    const {token, appReady} = state.auth;
+    const {sitesShouldUpdate} = state.addSite;
+
+
+    return {lastKnownRegion, mapLoaded, viewStyle, token, appReady, sites, sitesShouldUpdate};
+}
+
+export default connect(mapStateToProps, {})(FilterScreen);

--- a/src/screens/FilterScreen.js
+++ b/src/screens/FilterScreen.js
@@ -1,60 +1,167 @@
 import React, {Component} from 'react';
-import {Text, ScrollView, View, StyleSheet} from 'react-native';
+import {Text, ScrollView, View, StyleSheet, Platform} from 'react-native';
 import {connect} from "react-redux";
 
+import _ from 'lodash';
+
+import {CheckBox, Button, Icon} from 'react-native-elements';
 import Accordion from 'react-native-collapsible/Accordion';
 
-import MapScreen from "../components/SearchMap";
-import {initializeMap, mapHasLoaded, updateRegion, updateViewStyle} from "../actions";
+import {checkboxWasClicked} from "../actions";
+
+import {navKeys} from '../constants';
+import {campsite, more_screen, reducerAlerts} from '../locale.en';
+import {campsiteIcon, grey} from "../styles";
+
+const {campsite_form: {accessibility, facilities, price, accessibility_options, facilities_options, price_options}} = campsite;
 
 
-const SECTIONS = [
+const ACCESSIBILITY = [
     {
-        title: 'Accessibility',
-        content: 'Lorem ipsum...'
-    },
+        title: accessibility,
+        content: accessibility_options
+    }
+];
+
+const FACILITIES = [
     {
-        title: 'Second',
-        content: 'Lorem ipsum...'
+        title: facilities,
+        content: facilities_options
+    }
+];
+
+const PRICE = [
+    {
+        title: price,
+        content: price_options
     }
 ];
 
 class FilterScreen extends Component {
 
+    componentWillMount() {
+        const {displaySites} = this.props;
+
+        this.props.navigation.setParams({siteCount: displaySites.length});
+    }
+
+    componentWillReceiveProps(nextProps) {
+        const nextSetOfSites = nextProps.displaySites;
+        const currentSites = this.props.displaySites;
+
+
+        if (nextSetOfSites.length !== currentSites.length) {
+            this.props.navigation.setParams({siteCount: nextSetOfSites.length});
+        }
+    }
+
+    static renderRightNavButton = (navigate, {siteCount}) => {
+        if (Platform.OS === 'ios') {
+            return (
+                <Button
+                    title={_.isUndefined(siteCount) ? '' : `${siteCount} Results`}
+                    onPress={() => navigate(navKeys.SEARCH)}
+                    backgroundColor="rgba(0,0,0,0)"
+                    color="rgba(0,122,255,1)"
+                />
+            );
+        } else if (Platform.OS === 'android') {
+            // android-specific code for navigation here
+        }
+    };
+
     static navigationOptions = (props) => {
-        const {navigation: {navigate}} = props;
+        const {navigation: {navigate, state: {params = {}}}} = props;
 
         return {
-            headerTitle: 'Filter Your Search'
+            headerRight: FilterScreen.renderRightNavButton(navigate, params)
         }
 
     };
 
-    renderHeader(section) {
+    renderHeader = (section, index, isActive) => {
         const {headerStyle, headerTextStyle} = styles;
 
         return (
             <View style={headerStyle}>
-                <Text style={headerTextStyle}>{section.title}</Text>
+                <Text style={headerTextStyle}>
+                    {section.title}
+
+                </Text>
+                <Icon type='entypo' name={isActive ? 'chevron-down' : 'chevron-up'} size={25} color={campsiteIcon}/>
             </View>
         );
-    }
+    };
 
-    renderContent(section) {
+    onClickCheckbox = (key) => {
+        this.props.checkboxWasClicked({filterKey: key})
+    };
+
+    renderCheckedState = (key) => {
+        const {filterCriteriaKeys} = this.props;
+        const flatFilterCriteriaList = _(filterCriteriaKeys)
+            .map(categoryKeys => {
+                return _.map(categoryKeys, innerKey => innerKey)
+            })
+            .flatten()
+            .valueOf();
+
+        return _.includes(flatFilterCriteriaList, key);
+    };
+
+    renderCheckboxes = (checkboxObject) => {
+        return _.map(checkboxObject, (value, key) => {
+            return (
+                <CheckBox
+                    key={key}
+                    title={value}
+                    checked={this.renderCheckedState(key)}
+                    onPress={() => this.onClickCheckbox(key)}
+                />
+            );
+        })
+    };
+
+    renderContent = (section) => {
         const {contentStyle, contentTextStyle} = styles;
 
         return (
             <View style={contentStyle}>
-                <Text>{section.content}</Text>
+                {this.renderCheckboxes(section.content)}
             </View>
         );
-    }
+    };
 
-    render(){
-        return(
-            <ScrollView>
+    render() {
+        const {filterCriteriaKeys} = this.props;
+        const {mainContainerStyle, accordionFilterStyle} = styles;
+        const collapsedState = filterCriteriaKeys.accessibility.length > 0 || filterCriteriaKeys.facilities.length > 0 || filterCriteriaKeys.price.length > 0 ? 0 : -1;
+
+        return (
+            <ScrollView style={mainContainerStyle}>
                 <Accordion
-                    sections={SECTIONS}
+                    underlayColor={'#00000000'}
+                    initiallyActiveSection={collapsedState}
+                    style={accordionFilterStyle}
+                    sections={ACCESSIBILITY}
+                    renderHeader={this.renderHeader}
+                    renderContent={this.renderContent}
+                />
+
+                <Accordion
+                    underlayColor={'#00000000'}
+                    initiallyActiveSection={collapsedState}
+                    style={accordionFilterStyle}
+                    sections={FACILITIES}
+                    renderHeader={this.renderHeader}
+                    renderContent={this.renderContent}
+                />
+
+                <Accordion
+                    underlayColor={'#00000000'}
+                    initiallyActiveSection={collapsedState}
+                    style={accordionFilterStyle}
+                    sections={PRICE}
                     renderHeader={this.renderHeader}
                     renderContent={this.renderContent}
                 />
@@ -64,19 +171,28 @@ class FilterScreen extends Component {
 }
 
 const styles = StyleSheet.create({
-    headerStyle: {},
+    mainContainerStyle: {
+        margin: 30
+    },
+    accordionFilterStyle: {},
+    headerStyle: {
+        height: 30,
+        marginTop: 30,
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        paddingRight: 30
+    },
     headerTextStyle: {},
-    contentStyle:{},
-    contentTextStyle:{}
+    contentStyle: {},
+    contentTextStyle: {}
 });
 
 function mapStateToProps(state) {
-    const {lastKnownRegion, mapLoaded, viewStyle, sites} = state.map;
-    const {token, appReady} = state.auth;
-    const {sitesShouldUpdate} = state.addSite;
+    const {displaySites, filterCriteriaKeys} = state.map;
 
 
-    return {lastKnownRegion, mapLoaded, viewStyle, token, appReady, sites, sitesShouldUpdate};
+    return {displaySites, filterCriteriaKeys};
 }
 
-export default connect(mapStateToProps, {})(FilterScreen);
+export default connect(mapStateToProps, {checkboxWasClicked})(FilterScreen);

--- a/src/screens/SearchScreen.js
+++ b/src/screens/SearchScreen.js
@@ -71,7 +71,7 @@ class SearchScreen extends Component {
             return (
                 <Button
                     title="Filter"
-                    onPress={() => navigate('filter')}
+                    onPress={() => navigate(navKeys.FILTER)}
                     backgroundColor="rgba(0,0,0,0)"
                     color="rgba(0,122,255,1)"
                 />
@@ -95,7 +95,7 @@ class SearchScreen extends Component {
     };
 
     renderSearchScreen = () => {
-        const {viewStyle, lastKnownRegion, mapLoaded, sites} = this.props;
+        const {viewStyle, lastKnownRegion, mapLoaded, displaySites} = this.props;
 
         if (viewStyle === map.SearchOptions.MAP) {
             return (
@@ -103,13 +103,13 @@ class SearchScreen extends Component {
                     lastKnownRegion={lastKnownRegion}
                     mapLoaded={mapLoaded}
                     updateRegion={this.props.updateRegion}
-                    sites={sites}
+                    sites={displaySites}
                 />
             );
         } else {
             return (
                 <SearchList
-                    sites={sites}
+                    sites={displaySites}
                 />
             );
         }
@@ -143,12 +143,12 @@ const styles = StyleSheet.create({
 });
 
 function mapStateToProps(state) {
-    const {lastKnownRegion, mapLoaded, viewStyle, sites} = state.map;
+    const {lastKnownRegion, mapLoaded, viewStyle, displaySites} = state.map;
     const {token, appReady} = state.auth;
     const {sitesShouldUpdate} = state.addSite;
 
 
-    return {lastKnownRegion, mapLoaded, viewStyle, token, appReady, sites, sitesShouldUpdate};
+    return {lastKnownRegion, mapLoaded, viewStyle, token, appReady, displaySites, sitesShouldUpdate};
 }
 
 export default connect(mapStateToProps, {initializeMap, updateViewStyle, mapHasLoaded, updateRegion})(SearchScreen);


### PR DESCRIPTION
I did a few different things in this PR:
 * Changed the logic a bit for facilities (since it was really a combination of both facilities and price) and created a price attribute as well
 * Added the price attribute to the `AddSiteScreen`
 * Built out the `FilterScreen` to be filterable by `accessibility`, `facilities`, or `price`
 * The `FilterScreen` uses `react-native-collapsible` to collapse the filter options (@amgoodman5 I'm open to a different library if we find a better one)
 * Added logic to the collapsible areas to track if they're expanded or not and toggle their icons appropriately. Also, if there are any items that we're filtering by, the collapsables always default to being open in their initial state (so you don't go into the `FilterScreen` and not realize that something is hidden
 * Added a dynamic navigation header on the top right which tells you how many results you have as a result of your filtering
 * BASIC styling (@amgoodman5 this needs a lot of love... go nuts!)