### PR TITLE
Gh 57 && GH 56 -- FilterScreen enhancements and now passing keys of all text values to FireBase instead of their string versions

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
     "privacy": "unlisted",
     "sdkVersion": "24.0.0",
     "platforms": ["ios", "android"],
-    "version": "0.0.9",
+    "version": "0.0.10",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "splash": {

--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
     "privacy": "unlisted",
     "sdkVersion": "24.0.0",
     "platforms": ["ios", "android"],
-    "version": "0.0.7",
+    "version": "0.0.8",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "splash": {

--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
     "privacy": "unlisted",
     "sdkVersion": "24.0.0",
     "platforms": ["ios", "android"],
-    "version": "0.0.8",
+    "version": "0.0.9",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "splash": {

--- a/src/actions/MapActions.js
+++ b/src/actions/MapActions.js
@@ -5,6 +5,7 @@ import _ from 'lodash';
 
 import {
     INITIALIZE_MAP,
+    MAP_IS_INITIALIZING,
     MAP_READY,
     MAP_NOT_READY,
     MAP_REGION_CHANGE,
@@ -13,9 +14,13 @@ import {
 import {navKeys, tokens} from "../constants";
 
 
-export const initializeMap = (region) => {
+export const initializeMap = ({region}) => {
 
     return (dispatch) => {
+        dispatch({
+            type: MAP_IS_INITIALIZING
+        });
+
         firebase.firestore().collection('campsites')
             .get()
             .then(querySnapshot => {

--- a/src/actions/SearchAndFilterActions.js
+++ b/src/actions/SearchAndFilterActions.js
@@ -1,5 +1,6 @@
 import {
     FILTER_CRITERIA_UPDATED,
+    FILTER_TOGGLE_LOGIC_UPDATED,
     FILTER_CRITERIA_RESET
 } from './types';
 
@@ -8,6 +9,13 @@ export const checkboxWasClicked = ({filterKey}) => {
     return {
         type: FILTER_CRITERIA_UPDATED,
         payload: {filterKey}
+    }
+};
+
+export const filterToggleLogicUpdated = ({filterToggleKey}) => {
+    return {
+        type: FILTER_TOGGLE_LOGIC_UPDATED,
+        payload: {filterToggleKey}
     }
 };
 

--- a/src/actions/SearchAndFilterActions.js
+++ b/src/actions/SearchAndFilterActions.js
@@ -1,11 +1,18 @@
 import {
-    FILTER_CRITERIA_UPDATED
+    FILTER_CRITERIA_UPDATED,
+    FILTER_CRITERIA_RESET
 } from './types';
 
 
 export const checkboxWasClicked = ({filterKey}) => {
-    return{
+    return {
         type: FILTER_CRITERIA_UPDATED,
         payload: {filterKey}
+    }
+};
+
+export const resetAllFilters = () => {
+    return {
+        type: FILTER_CRITERIA_RESET
     }
 };

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -6,6 +6,7 @@ export const FACEBOOK_LOGIN_FAILURE = 'fb_login_failure';
 export const FACEBOOK_LOGOUT_COMPLETE = 'fb_logout_complete';
 
 export const INITIALIZE_MAP = 'initialize_map';
+export const MAP_IS_INITIALIZING = 'map_is_initializing';
 export const MAP_READY = 'map_ready';
 export const MAP_NOT_READY = 'map_not_ready';
 export const MAP_REGION_CHANGE = 'map_region_change';
@@ -28,6 +29,7 @@ export const CHECK_IF_SITE_IS_READY = 'check_if_site_is_ready';
 export const SITE_DETAIL_CHECKBOX_UPDATED = 'site_detail_checkbox_updated';
 
 export const FILTER_CRITERIA_UPDATED = 'filter_criteria_updated';
+export const FILTER_TOGGLE_LOGIC_UPDATED = 'filter_toggle_logic_updated';
 export const FILTER_CRITERIA_RESET = 'filter_criteria_reset';
 
 export const LOCATION_SERVICES_PERMISSION_UPDATED = 'location_services_permission_updated';

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -28,6 +28,7 @@ export const CHECK_IF_SITE_IS_READY = 'check_if_site_is_ready';
 export const SITE_DETAIL_CHECKBOX_UPDATED = 'site_detail_checkbox_updated';
 
 export const FILTER_CRITERIA_UPDATED = 'filter_criteria_updated';
+export const FILTER_CRITERIA_RESET = 'filter_criteria_reset';
 
 export const LOCATION_SERVICES_PERMISSION_UPDATED = 'location_services_permission_updated';
 export const CAMERA_PERMISSION_UPDATED = 'camera_permission_updated';

--- a/src/locale.en.js
+++ b/src/locale.en.js
@@ -65,6 +65,10 @@ export const campsite = {
             secluded: 'Secluded',
             mountain_views: 'Mountain Views',
             easy_access: 'Easy Access'
+        },
+        filter: {
+            any_of_these: 'Any of these',
+            exactly_these: 'Exactly these'
         }
     }
 };

--- a/src/reducers/AddSiteReducer.js
+++ b/src/reducers/AddSiteReducer.js
@@ -15,7 +15,7 @@ import {
     CHECK_IF_SITE_IS_READY,
     ADD_SITE_SUCCESS,
     ADD_SITE_FAILURE,
-    INITIALIZE_MAP,
+    MAP_IS_INITIALIZING,
     SITE_DETAIL_CHECKBOX_UPDATED,
     FACEBOOK_LOGOUT_COMPLETE
 } from '../actions/types';
@@ -149,8 +149,8 @@ export default (state = INITIAL_STATE, action) => {
         case ADD_SITE_FAILURE:
             return {...state};
 
-        case INITIALIZE_MAP:
-            return {...state};
+        case MAP_IS_INITIALIZING:
+            return {...state, sitesShouldUpdate: false};
 
         case FACEBOOK_LOGOUT_COMPLETE:
             return INITIAL_STATE;

--- a/src/reducers/AddSiteReducer.js
+++ b/src/reducers/AddSiteReducer.js
@@ -16,7 +16,8 @@ import {
     ADD_SITE_SUCCESS,
     ADD_SITE_FAILURE,
     INITIALIZE_MAP,
-    SITE_DETAIL_CHECKBOX_UPDATED
+    SITE_DETAIL_CHECKBOX_UPDATED,
+    FACEBOOK_LOGOUT_COMPLETE
 } from '../actions/types';
 
 import {campsite, reducerAlerts} from '../locale.en';
@@ -150,6 +151,9 @@ export default (state = INITIAL_STATE, action) => {
 
         case INITIALIZE_MAP:
             return {...state};
+
+        case FACEBOOK_LOGOUT_COMPLETE:
+            return INITIAL_STATE;
 
         default:
             return state;

--- a/src/reducers/MapReducer.js
+++ b/src/reducers/MapReducer.js
@@ -6,7 +6,8 @@ import {
     MAP_READY,
     MAP_REGION_CHANGE,
     FACEBOOK_LOGOUT_COMPLETE,
-    FILTER_CRITERIA_UPDATED
+    FILTER_CRITERIA_UPDATED,
+    FILTER_CRITERIA_RESET
 
 } from '../actions/types';
 
@@ -156,6 +157,11 @@ export default (state = INITIAL_STATE, action) => {
             const newlyFilteredSites = filterSites(state, updatedFilterKeys);
 
             return {...state, filterCriteriaKeys: updatedFilterKeys, displaySites: newlyFilteredSites};
+
+        case FILTER_CRITERIA_RESET:
+            const filterResetSites = filterSites(state, INITIAL_STATE.filterCriteriaKeys);
+
+            return {...state , filterCriteriaKeys: INITIAL_STATE.filterCriteriaKeys, displaySites: filterResetSites};
 
 
         default:

--- a/src/reducers/MapReducer.js
+++ b/src/reducers/MapReducer.js
@@ -194,7 +194,7 @@ export default (state = INITIAL_STATE, action) => {
         case FILTER_CRITERIA_RESET:
             const filterResetSites = filterSites(state, INITIAL_STATE.filterCriteriaKeys);
 
-            return {...state, filterCriteriaKeys: INITIAL_STATE.filterCriteriaKeys, displaySites: filterResetSites};
+            return {...state, filterCriteriaKeys: INITIAL_STATE.filterCriteriaKeys, filterResultsScrutinyLoose: INITIAL_STATE.filterResultsScrutinyLoose, displaySites: filterResetSites};
 
         case FILTER_TOGGLE_LOGIC_UPDATED:
             const {filterToggleKey} = payload;

--- a/src/reducers/MapReducer.js
+++ b/src/reducers/MapReducer.js
@@ -7,6 +7,7 @@ import {
     MAP_REGION_CHANGE,
     FACEBOOK_LOGOUT_COMPLETE,
     FILTER_CRITERIA_UPDATED,
+    FILTER_TOGGLE_LOGIC_UPDATED,
     FILTER_CRITERIA_RESET
 
 } from '../actions/types';
@@ -57,7 +58,16 @@ const INITIAL_STATE = {
     viewStyle: map.SearchOptions.MAP,
     sites: [],
     displaySites: [],
+    filterResultsScrutinyLoose: {facilities: true, features: true},
     filterCriteriaKeys: {accessibility: [], facilities: [], price: [], features: []}
+};
+
+const updateFilterResultsScrutiny = ({filterResultsScrutinyLoose}, filterToggleKey) => {
+    let filterResultsScrutinyClone = _.cloneDeep(filterResultsScrutinyLoose);
+
+    filterResultsScrutinyClone[filterToggleKey] = !filterResultsScrutinyClone[filterToggleKey];
+
+    return filterResultsScrutinyClone;
 };
 
 const updateFilterKeys = ({filterCriteriaKeys}, filterKey) => {
@@ -136,7 +146,8 @@ export default (state = INITIAL_STATE, action) => {
                 sites: sites,
                 filterCriteriaKeys: state.filterCriteriaKeys,
                 displaySites: filterSites({sites}, state.filterCriteriaKeys),
-                mapLoaded: existingMapLoadedState
+                mapLoaded: existingMapLoadedState,
+                filterResultsScrutinyLoose: state.filterResultsScrutinyLoose
             } : INITIAL_STATE;
 
         case VIEW_STYLE_UPDATE:
@@ -161,8 +172,13 @@ export default (state = INITIAL_STATE, action) => {
         case FILTER_CRITERIA_RESET:
             const filterResetSites = filterSites(state, INITIAL_STATE.filterCriteriaKeys);
 
-            return {...state , filterCriteriaKeys: INITIAL_STATE.filterCriteriaKeys, displaySites: filterResetSites};
+            return {...state, filterCriteriaKeys: INITIAL_STATE.filterCriteriaKeys, displaySites: filterResetSites};
 
+        case FILTER_TOGGLE_LOGIC_UPDATED:
+            const {filterToggleKey} = payload;
+            const updatedFilterResultsScrutinyLooseObject = updateFilterResultsScrutiny(state, filterToggleKey);
+
+            return {...state, filterResultsScrutinyLoose: updatedFilterResultsScrutinyLooseObject};
 
         default:
             return state;

--- a/src/screens/AddSiteFormScreen.js
+++ b/src/screens/AddSiteFormScreen.js
@@ -167,9 +167,12 @@ class AddSiteFormScreen extends Component {
     };
 
     renderCheckboxes = (checkboxObject) => {
+        const {addSiteCheckboxRowStyle} = styles;
+
         return _.map(checkboxObject, (value, key) => {
             return (
                 <CheckBox
+                    containerStyle={addSiteCheckboxRowStyle}
                     key={key}
                     title={value}
                     checked={this.renderCheckedState(key)}
@@ -391,6 +394,9 @@ const styles = {
         paddingRight: 20,
         flexDirection: 'row',
         justifyContent: 'space-between'
+    },
+    addSiteCheckboxRowStyle: {
+        margin: 0
     }
 
 };

--- a/src/screens/AddSiteFormScreen.js
+++ b/src/screens/AddSiteFormScreen.js
@@ -329,20 +329,20 @@ class AddSiteFormScreen extends Component {
                         editable={true}
                     />
 
-                    <FormLabel>{price}</FormLabel>
-                    <Picker
-                        selectedValue={priceOption}
-                        onValueChange={this.onUpdatePriceOption}
-                    >
-                        {this.priceOptions()}
-                    </Picker>
-
                     <FormLabel>{accessibility}</FormLabel>
                     <Picker
                         selectedValue={accessibilityOption}
                         onValueChange={this.onUpdateAccessibilityOption}
                     >
                         {this.accessibilityOptions()}
+                    </Picker>
+
+                    <FormLabel>{price}</FormLabel>
+                    <Picker
+                        selectedValue={priceOption}
+                        onValueChange={this.onUpdatePriceOption}
+                    >
+                        {this.priceOptions()}
                     </Picker>
 
                     <FormLabel>{facilities}</FormLabel>

--- a/src/screens/AddSiteFormScreen.js
+++ b/src/screens/AddSiteFormScreen.js
@@ -104,19 +104,13 @@ class AddSiteFormScreen extends Component {
 
     accessibilityOptions() {
         return Object.keys(accessibility_options).map((key) => {
-            return <Picker.Item key={key} label={accessibility_options[key]} value={accessibility_options[key]}/>;
-        })
-    }
-
-    facilitiesOptions() {
-        return Object.keys(facilities_options).map((key) => {
-            return <Picker.Item key={key} label={facilities_options[key]} value={facilities_options[key]}/>;
+            return <Picker.Item key={key} label={accessibility_options[key]} value={key}/>;
         })
     }
 
     priceOptions() {
         return Object.keys(price_options).map((key) => {
-            return <Picker.Item key={key} label={price_options[key]} value={price_options[key]}/>;
+            return <Picker.Item key={key} label={price_options[key]} value={key}/>;
         })
     }
 

--- a/src/screens/FilterScreen.js
+++ b/src/screens/FilterScreen.js
@@ -13,7 +13,7 @@ import {map, navKeys} from '../constants';
 import {campsite, more_screen, reducerAlerts} from '../locale.en';
 import {campsiteIcon, grey} from "../styles";
 
-const {campsite_form: {accessibility, facilities, price, features, accessibility_options, facilities_options, price_options, features_options, reset}} = campsite;
+const {campsite_form: {accessibility, facilities, price, features, accessibility_options, facilities_options, price_options, features_options, reset, filter}} = campsite;
 
 
 const ACCESSIBILITY = [
@@ -111,10 +111,11 @@ class FilterScreen extends Component {
 
         return (
             <View style={headerStyle}>
-                <Text style={headerTextStyle}>
-                    {section.title}
-
-                </Text>
+                <View style={headerTextStyle}>
+                    <Text>
+                        {section.title}
+                    </Text>
+                </View>
                 <Icon type='entypo' name={isActive ? 'chevron-down' : 'chevron-up'} size={25} color={campsiteIcon}/>
             </View>
         );
@@ -137,9 +138,12 @@ class FilterScreen extends Component {
     };
 
     renderCheckboxes = (checkboxObject) => {
+        const {checkBoxRowStyle} = styles;
+
         return _.map(checkboxObject, (value, key) => {
             return (
                 <CheckBox
+                    containerStyle={checkBoxRowStyle}
                     key={key}
                     title={value}
                     checked={this.renderCheckedState(key)}
@@ -162,12 +166,12 @@ class FilterScreen extends Component {
 
             return (
                 <View style={toggleContainerStyle}>
-                    <Text>Exactly These</Text>
+                    <Text>{filter.exactly_these}</Text>
                     <Switch
                         onValueChange={() => this.onFilterScrutinyToggleChange({filterToggleKey: lowercaseTitle})}
                         value={filterResultsScrutinyLoose[lowercaseTitle]}
                     />
-                    <Text>Some of These</Text>
+                    <Text>{filter.any_of_these}</Text>
                 </View>
             )
         }
@@ -186,11 +190,15 @@ class FilterScreen extends Component {
 
     render() {
         const {filterCriteriaKeys} = this.props;
-        const {mainContainerStyle, accordionFilterStyle} = styles;
+        const {mainContainerStyle, accordionFilterStyle, topSpaceStyle, bottomSpaceStyle} = styles;
         const collapsedState = filterCriteriaKeys.accessibility.length > 0 || filterCriteriaKeys.facilities.length > 0 || filterCriteriaKeys.features.length > 0 || filterCriteriaKeys.price.length > 0 ? 0 : -1;
 
         return (
             <ScrollView style={mainContainerStyle}>
+                <View style={topSpaceStyle}>
+
+                </View>
+
                 <Accordion
                     underlayColor={'#00000000'}
                     initiallyActiveSection={collapsedState}
@@ -227,33 +235,52 @@ class FilterScreen extends Component {
                     renderContent={this.renderContent}
                 />
 
+                <View style={bottomSpaceStyle}>
+
+                </View>
+
             </ScrollView>
         );
     }
 }
 
 const styles = StyleSheet.create({
+    topSpaceStyle: {
+        marginBottom: 30
+    },
+    bottomSpaceStyle: {
+        marginTop: 50
+    },
     mainContainerStyle: {
-        margin: 30
     },
     accordionFilterStyle: {},
     headerStyle: {
-        height: 30,
-        marginTop: 30,
+        height: 50,
         display: 'flex',
         flexDirection: 'row',
         justifyContent: 'space-between',
-        paddingRight: 30
+        alignContent: 'center',
+        paddingLeft: 50,
+        paddingRight: 30,
+        backgroundColor: 'white'
     },
     toggleContainerStyle: {
+        marginTop: 20,
+        marginBottom: 10,
         display: 'flex',
         flexDirection: 'row',
         justifyContent: 'space-around',
         alignContent: 'center'
     },
-    headerTextStyle: {},
+    headerTextStyle: {
+        justifyContent: 'center',
+        alignItems: 'center'
+    },
     contentStyle: {},
-    contentTextStyle: {}
+    contentTextStyle: {},
+    checkBoxRowStyle: {
+        margin: 0
+    }
 });
 
 function mapStateToProps(state) {

--- a/src/screens/FilterScreen.js
+++ b/src/screens/FilterScreen.js
@@ -187,7 +187,7 @@ class FilterScreen extends Component {
     render() {
         const {filterCriteriaKeys} = this.props;
         const {mainContainerStyle, accordionFilterStyle} = styles;
-        const collapsedState = filterCriteriaKeys.accessibility.length > 0 || filterCriteriaKeys.facilities.length > 0 || filterCriteriaKeys.price.length > 0 ? 0 : -1;
+        const collapsedState = filterCriteriaKeys.accessibility.length > 0 || filterCriteriaKeys.facilities.length > 0 || filterCriteriaKeys.features.length > 0 || filterCriteriaKeys.price.length > 0 ? 0 : -1;
 
         return (
             <ScrollView style={mainContainerStyle}>

--- a/src/screens/FilterScreen.js
+++ b/src/screens/FilterScreen.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {Text, ScrollView, View, StyleSheet, Platform} from 'react-native';
+import {Text, ScrollView, View, StyleSheet, Platform, Switch} from 'react-native';
 import {connect} from "react-redux";
 
 import _ from 'lodash';
@@ -7,7 +7,7 @@ import _ from 'lodash';
 import {CheckBox, Button, Icon} from 'react-native-elements';
 import Accordion from 'react-native-collapsible/Accordion';
 
-import {checkboxWasClicked, resetAllFilters} from "../actions";
+import {checkboxWasClicked, resetAllFilters, filterToggleLogicUpdated} from "../actions";
 
 import {map, navKeys} from '../constants';
 import {campsite, more_screen, reducerAlerts} from '../locale.en';
@@ -149,11 +149,36 @@ class FilterScreen extends Component {
         })
     };
 
+    onFilterScrutinyToggleChange = ({filterToggleKey}) => {
+        this.props.filterToggleLogicUpdated({filterToggleKey});
+    };
+
+    renderToggleSwitch = ({title}) => {
+        const {toggleContainerStyle} = styles;
+        const {filterResultsScrutinyLoose} = this.props;
+
+        if (title === features || title === facilities) {
+            const lowercaseTitle = _.toLower(title);
+
+            return (
+                <View style={toggleContainerStyle}>
+                    <Text>Exactly These</Text>
+                    <Switch
+                        onValueChange={() => this.onFilterScrutinyToggleChange({filterToggleKey: lowercaseTitle})}
+                        value={filterResultsScrutinyLoose[lowercaseTitle]}
+                    />
+                    <Text>Some of These</Text>
+                </View>
+            )
+        }
+    };
+
     renderContent = (section) => {
         const {contentStyle} = styles;
 
         return (
             <View style={contentStyle}>
+                {this.renderToggleSwitch(section)}
                 {this.renderCheckboxes(section.content)}
             </View>
         );
@@ -220,16 +245,22 @@ const styles = StyleSheet.create({
         justifyContent: 'space-between',
         paddingRight: 30
     },
+    toggleContainerStyle: {
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'space-around',
+        alignContent: 'center'
+    },
     headerTextStyle: {},
     contentStyle: {},
     contentTextStyle: {}
 });
 
 function mapStateToProps(state) {
-    const {displaySites, filterCriteriaKeys} = state.map;
+    const {displaySites, filterCriteriaKeys, filterResultsScrutinyLoose} = state.map;
 
 
-    return {displaySites, filterCriteriaKeys};
+    return {displaySites, filterCriteriaKeys, filterResultsScrutinyLoose};
 }
 
-export default connect(mapStateToProps, {checkboxWasClicked, resetAllFilters})(FilterScreen);
+export default connect(mapStateToProps, {checkboxWasClicked, resetAllFilters, filterToggleLogicUpdated})(FilterScreen);

--- a/src/screens/FilterScreen.js
+++ b/src/screens/FilterScreen.js
@@ -7,13 +7,13 @@ import _ from 'lodash';
 import {CheckBox, Button, Icon} from 'react-native-elements';
 import Accordion from 'react-native-collapsible/Accordion';
 
-import {checkboxWasClicked} from "../actions";
+import {checkboxWasClicked, resetAllFilters} from "../actions";
 
-import {navKeys} from '../constants';
+import {map, navKeys} from '../constants';
 import {campsite, more_screen, reducerAlerts} from '../locale.en';
 import {campsiteIcon, grey} from "../styles";
 
-const {campsite_form: {accessibility, facilities, price, accessibility_options, facilities_options, price_options}} = campsite;
+const {campsite_form: {accessibility, facilities, price, features, accessibility_options, facilities_options, price_options, features_options, reset}} = campsite;
 
 
 const ACCESSIBILITY = [
@@ -30,6 +30,13 @@ const FACILITIES = [
     }
 ];
 
+const FEATURES = [
+    {
+        title: features,
+        content: features_options
+    }
+];
+
 const PRICE = [
     {
         title: price,
@@ -42,7 +49,7 @@ class FilterScreen extends Component {
     componentWillMount() {
         const {displaySites} = this.props;
 
-        this.props.navigation.setParams({siteCount: displaySites.length});
+        this.props.navigation.setParams({siteCount: displaySites.length, onClickReset: this.onClickReset});
     }
 
     componentWillReceiveProps(nextProps) {
@@ -55,7 +62,11 @@ class FilterScreen extends Component {
         }
     }
 
-    static renderRightNavButton = (navigate, {siteCount}) => {
+    onClickReset = () => {
+        this.props.resetAllFilters();
+    };
+
+    static renderHeaderTitleButton = (navigate, {siteCount}) => {
         if (Platform.OS === 'ios') {
             return (
                 <Button
@@ -70,10 +81,26 @@ class FilterScreen extends Component {
         }
     };
 
+    static renderRightNavButton = (navigate, {onClickReset}) => {
+        if (Platform.OS === 'ios') {
+            return (
+                <Button
+                    title={reset}
+                    onPress={onClickReset}
+                    backgroundColor="rgba(0,0,0,0)"
+                    color="rgba(0,122,255,1)"
+                />
+            );
+        } else if (Platform.OS === 'android') {
+            // android-specific code for navigation here
+        }
+    };
+
     static navigationOptions = (props) => {
         const {navigation: {navigate, state: {params = {}}}} = props;
 
         return {
+            headerTitle: FilterScreen.renderHeaderTitleButton(navigate, params),
             headerRight: FilterScreen.renderRightNavButton(navigate, params)
         }
 
@@ -152,6 +179,15 @@ class FilterScreen extends Component {
                     underlayColor={'#00000000'}
                     initiallyActiveSection={collapsedState}
                     style={accordionFilterStyle}
+                    sections={PRICE}
+                    renderHeader={this.renderHeader}
+                    renderContent={this.renderContent}
+                />
+
+                <Accordion
+                    underlayColor={'#00000000'}
+                    initiallyActiveSection={collapsedState}
+                    style={accordionFilterStyle}
                     sections={FACILITIES}
                     renderHeader={this.renderHeader}
                     renderContent={this.renderContent}
@@ -161,10 +197,11 @@ class FilterScreen extends Component {
                     underlayColor={'#00000000'}
                     initiallyActiveSection={collapsedState}
                     style={accordionFilterStyle}
-                    sections={PRICE}
+                    sections={FEATURES}
                     renderHeader={this.renderHeader}
                     renderContent={this.renderContent}
                 />
+
             </ScrollView>
         );
     }
@@ -195,4 +232,4 @@ function mapStateToProps(state) {
     return {displaySites, filterCriteriaKeys};
 }
 
-export default connect(mapStateToProps, {checkboxWasClicked})(FilterScreen);
+export default connect(mapStateToProps, {checkboxWasClicked, resetAllFilters})(FilterScreen);

--- a/src/screens/SearchScreen.js
+++ b/src/screens/SearchScreen.js
@@ -19,7 +19,7 @@ class SearchScreen extends Component {
     componentWillMount() {
         const {lastKnownRegion} = this.props;
 
-        this.props.initializeMap(lastKnownRegion);
+        this.props.initializeMap({region: lastKnownRegion});
     }
 
     componentDidMount() {
@@ -33,8 +33,8 @@ class SearchScreen extends Component {
     componentWillReceiveProps(nextProps){
         const {sitesShouldUpdate, lastKnownRegion} = nextProps;
 
-        if(sitesShouldUpdate){
-            this.props.initializeMap(lastKnownRegion);
+        if(sitesShouldUpdate && sitesShouldUpdate !== this.props.sitesShouldUpdate){
+            this.props.initializeMap({region: lastKnownRegion});
         }
 
     }


### PR DESCRIPTION
* This PR focuses mostly on GH-57 -- Filtering for facilities and features should have the option of 'all of these' or 'some of these'
   * `Exactly these` and `Any of these` logic has been added to filter
   * Did a bit more styling on the checkboxes and dropdowns in the `FilterScreen
* PR also includes the fix for GH-56  -- All options sent to Firebase that are not freeform text should be in their keys instead of text translations
* Also moved the `## Results` info to the center of the header in `FilterScreen` and added a `Reset` option on the top right
* Also includes other cleanup things like making sure that all screens are cleared upon logout 
